### PR TITLE
Add FastAPI backend and NextAuth authentication

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,57 @@
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from . import models, database
+
+SECRET_KEY = os.getenv("SECRET_KEY", "supersecret")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+def get_user_by_email(db: Session, email: str) -> Optional[models.User]:
+    return db.query(models.User).filter(models.User.email == email).first()
+
+def authenticate_user(db: Session, email: str, password: str) -> Optional[models.User]:
+    user = get_user_by_email(db, email)
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(database.get_db)) -> models.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: str = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = get_user_by_email(db, email=email)
+    if user is None:
+        raise credentials_exception
+    return user

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,16 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/pakshopper")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,41 @@
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import Session
+
+from . import auth, database, models, schemas
+
+models.Base.metadata.create_all(bind=database.engine)
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.post("/signup", response_model=schemas.UserOut)
+def signup(user: schemas.UserCreate, db: Session = Depends(database.get_db)):
+    existing = auth.get_user_by_email(db, user.email)
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    hashed = auth.get_password_hash(user.password)
+    db_user = models.User(email=user.email, name=user.name, hashed_password=hashed)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+@app.post("/login", response_model=schemas.Token)
+def login(data: schemas.UserLogin, db: Session = Depends(database.get_db)):
+    user = auth.authenticate_user(db, data.email, data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect email or password")
+    access_token = auth.create_access_token({"sub": user.email})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+@app.get("/me", response_model=schemas.UserOut)
+def read_users_me(current_user = Depends(auth.get_current_user)):
+    return current_user

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    name = Column(String, nullable=False)
+    hashed_password = Column(String, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+SQLAlchemy
+passlib[bcrypt]
+python-jose
+psycopg2-binary

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+class UserCreate(BaseModel):
+    email: str
+    name: str
+    password: str
+
+class UserOut(BaseModel):
+    id: int
+    email: str
+    name: str
+
+    class Config:
+        orm_mode = True
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+class UserLogin(BaseModel):
+    email: str
+    password: str

--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,49 @@
+import NextAuth from "next-auth"
+import CredentialsProvider from "next-auth/providers/credentials"
+
+const handler = NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/login`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: credentials.email,
+            password: credentials.password,
+          }),
+        })
+        if (!res.ok) return null
+        const data = await res.json()
+        return {
+          id: credentials.email,
+          email: credentials.email,
+          accessToken: data.access_token,
+        }
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user?.accessToken) {
+        token.accessToken = user.accessToken
+      }
+      return token
+    },
+    async session({ session, token }) {
+      if (token?.accessToken) {
+        session.accessToken = token.accessToken as string
+      }
+      return session
+    },
+  },
+})
+
+export { handler as GET, handler as POST }

--- a/frontend/app/cart/page.tsx
+++ b/frontend/app/cart/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { ArrowLeft, Trash2, Edit3, Package, ShoppingBag, AlertCircle } from 'lucide-react'
 import Link from 'next/link'
 import Navbar from '../../components/Navbar'
 import Footer from '../../components/Footer'
 import { useCart } from '../../contexts/CartContext'
 import type { CartItem } from '../../contexts/CartContext'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 // Utility function for formatting dates
 const formatDate = (date: Date) => {
@@ -21,6 +23,28 @@ const CartPage = () => {
   const { state, removeItem, clearCart, setCurrency } = useCart()
   const [editingItem, setEditingItem] = useState<string | null>(null)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
+  const { data: session, status } = useSession()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login')
+    }
+  }, [status, router])
+
+  if (status !== 'authenticated') {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Navbar />
+        <main className="pt-16">
+          <div className="container-custom py-16 text-center">
+            <p className="text-gray-600">Loading...</p>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    )
+  }
 
   const currencies = [
     { code: 'USD', symbol: '$', rate: 0.0036 },

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { CartProvider } from '../contexts/CartContext'
+import { SessionProvider } from 'next-auth/react'
 
 export const metadata: Metadata = {
   title: 'PakShopper - Your Trusted Pakistani Fashion Agent',
@@ -23,9 +24,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        <CartProvider>
-          {children}
-        </CartProvider>
+        <SessionProvider>
+          <CartProvider>
+            {children}
+          </CartProvider>
+        </SessionProvider>
       </body>
     </html>
   )

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import Navbar from '../../components/Navbar'
+import Footer from '../../components/Footer'
+
+const LoginPage = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await signIn('credentials', {
+      redirect: false,
+      email,
+      password,
+    })
+    if (res?.ok) {
+      router.push('/')
+    } else {
+      alert('Invalid credentials')
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar />
+      <main className="pt-16">
+        <div className="container-custom py-10">
+          <h1 className="text-3xl font-bold text-center text-gray-900 mb-8">Login</h1>
+          <form onSubmit={handleSubmit} className="max-w-lg mx-auto bg-white p-8 rounded-xl shadow-soft space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Email</label>
+              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="input-field w-full" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Password</label>
+              <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} className="input-field w-full" />
+            </div>
+            <button type="submit" className="w-full btn-primary py-3 text-lg">Login</button>
+          </form>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default LoginPage

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -80,10 +80,20 @@ const SignUpPage = () => {
     country.trim().length > 0 &&
     termsAccepted
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!isFormValid) return
-    alert('Account created (demo).')
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: fullName, email, password }),
+    })
+    if (res.ok) {
+      alert('Account created. Please log in.')
+    } else {
+      const data = await res.json().catch(() => ({}))
+      alert(data.detail || 'Signup failed')
+    }
   }
 
   return (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "lucide-react": "^0.294.0",
     "next": "^14.0.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "next-auth": "^4.24.5"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Summary
- introduce FastAPI backend with signup, login and JWT-protected endpoint
- integrate NextAuth credentials provider on frontend and add login page
- protect cart route and wire signup form to backend API

## Testing
- `pytest`
- `npm run lint` *(fails: interactive Next.js lint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c72e03fc832c8a31b1fb31fe3c83